### PR TITLE
Remove isl submodule in favor of nix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "isl"]
-	path = isl
-	url = git://repo.or.cz/isl.git


### PR DESCRIPTION
Both building and REPL use work now that we are using `shellHook` in `default.nix`.