### PR TITLE
Reorganize modules

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import ISL
-import ISL.Types (DimType(..))
+import ISL.Native.C2Hs
+import ISL.Native.Types (DimType(..))
 
 example1 :: String
 example1 = unlines

--- a/isl-hs.cabal
+++ b/isl-hs.cabal
@@ -18,9 +18,11 @@ cabal-version:       >=1.10
 library
   exposed-modules:
       ISL
-    , ISL.Context
+    , ISL.Native
+    , ISL.Native.Context
+    , ISL.Native.C2Hs
+    , ISL.Native.Types
     , ISL.Types
-    , InlineBindings
   -- other-modules:
   -- other-extensions:
   build-depends:

--- a/src/ISL.hs
+++ b/src/ISL.hs
@@ -1,0 +1,4 @@
+-- | High-level interface to isl.
+module ISL where
+
+import ISL.Types

--- a/src/ISL/Native.hs
+++ b/src/ISL/Native.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module InlineBindings
+-- | An inline-c based low-level interface to isl.
+module ISL.Native
   ( IslData(copy, free)
 
   , unsafeSetIntersect
@@ -35,8 +36,8 @@ import Foreign.Ptr
 import Foreign.C
 import qualified Language.C.Inline as C
 
-import ISL.Types
-import ISL.Context (islCtx)
+import ISL.Native.Context (islCtx)
+import ISL.Native.Types
 
 C.context islCtx
 

--- a/src/ISL/Native/C2Hs.chs
+++ b/src/ISL/Native/C2Hs.chs
@@ -1,5 +1,8 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-module ISL where
+
+-- | Prototype of a c2hs-based low-level interface. We will prefer a ISL.Native
+-- for now, which uses inline-c instead.
+module ISL.Native.C2Hs where
 
 #include <isl/ctx.h>
 #include <isl/constraint.h>
@@ -12,7 +15,7 @@ import Foreign.Marshal.Alloc
 import Foreign.Storable
 import Foreign.C
 
-import ISL.Types
+import ISL.Native.Types
 
 type PtrCtx = Ptr Ctx
 {#pointer *isl_ctx as PtrCtx -> Ctx nocode #}

--- a/src/ISL/Native/Context.hs
+++ b/src/ISL/Native/Context.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module ISL.Context (islCtx) where
+module ISL.Native.Context (islCtx) where
 
 import qualified Language.C.Inline as C
 import           Language.C.Inline.Context
@@ -11,7 +11,7 @@ import qualified Data.Map as Map
 import           Data.Monoid ((<>))
 import qualified Language.Haskell.TH as TH
 
-import ISL.Types
+import ISL.Native.Types
 
 islCtx :: C.Context
 islCtx = baseCtx <> bsCtx <> ctx

--- a/src/ISL/Native/Types.chs
+++ b/src/ISL/Native/Types.chs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
-module ISL.Types where
+-- | Types for the low-level interface to isl.
+module ISL.Native.Types where
 
 #include <isl/space.h>
 

--- a/src/ISL/Types.hs
+++ b/src/ISL/Types.hs
@@ -1,0 +1,2 @@
+-- | Types for the high-level interface to isl.
+module ISL.Types where


### PR DESCRIPTION
Move low-level interface under `ISL.Native`, making room for a new high-level interface in `ISL` and `ISL.Types`.